### PR TITLE
Add About page

### DIFF
--- a/portfolio/src/main/webapp/components/captionedimage.js
+++ b/portfolio/src/main/webapp/components/captionedimage.js
@@ -1,3 +1,7 @@
+/*
+ * An image with a title and caption to the left of it.
+ */
+
 const CaptionedImageTemplate = 
 `<div class="preview-img-w-text">
     <div class="preview-img-text">

--- a/portfolio/src/main/webapp/components/footer.js
+++ b/portfolio/src/main/webapp/components/footer.js
@@ -8,8 +8,8 @@ const FooterTemplate =
   <div class="footer-text">
     Last updated 2020.
     <a href="https://fonts.google.com/">Fonts.</a>
+    <a href="https://fontawesome.com/">Icons.</a>
   </div>
-</div>
 </div>`;
 
 const Footer = {

--- a/portfolio/src/main/webapp/components/footer.js
+++ b/portfolio/src/main/webapp/components/footer.js
@@ -1,3 +1,8 @@
+/*
+ * The footer at the bottom of every page.
+ * Dates the page and gives font credit.
+ */
+
 const FooterTemplate = 
 `<div id="footer-container">
   <div class="footer-text">

--- a/portfolio/src/main/webapp/components/icontitle.js
+++ b/portfolio/src/main/webapp/components/icontitle.js
@@ -1,0 +1,19 @@
+/*
+ * A FontAwesome icon to the left of a title.
+ * Used sequentially, all icons/text are vertically aligned.
+ */
+
+const IconTitleTemplate = 
+`<div class="icontitle-container">
+    <div class="icontitle-icon-container">
+        <div class="icontitle-icon"><i :class="icon"></i></div>
+    </div>
+    <h3><slot></slot></h3>
+</div>`;
+
+const IconTitle = {
+    props: ['icon'],
+    template: IconTitleTemplate,
+};
+
+export { IconTitle };

--- a/portfolio/src/main/webapp/components/navheader.js
+++ b/portfolio/src/main/webapp/components/navheader.js
@@ -3,9 +3,9 @@ const NavHeaderTemplate =
     <img id="header-img" src="./assets/me.jpg" alt="Profile picture">
     <span id="header">Melanie Gutzmann</span>
     <div id="nav-links">
-        <a class="nav-link" href="#">About</a>
-        <a class="nav-link" href="#">Projects</a>
-        <a class="nav-link" href="#">Contact</a>
+        <router-link class="nav-link" to="/about">About</router-link>
+        <router-link class="nav-link" href="/projects">Projects</router-link>
+        <router-link class="nav-link" href="/contact">Contact</router-link>
     </div>
 </div>`;
 

--- a/portfolio/src/main/webapp/components/navheader.js
+++ b/portfolio/src/main/webapp/components/navheader.js
@@ -1,11 +1,11 @@
 const NavHeaderTemplate = 
 `<div id="header-container">
     <img id="header-img" src="./assets/me.jpg" alt="Profile picture">
-    <span id="header">Melanie Gutzmann</span>
+    <router-link id="header" to="/">Melanie Gutzmann</router-link>
     <div id="nav-links">
         <router-link class="nav-link" to="/about">About</router-link>
-        <router-link class="nav-link" href="/projects">Projects</router-link>
-        <router-link class="nav-link" href="/contact">Contact</router-link>
+        <router-link class="nav-link" to="/projects">Projects</router-link>
+        <router-link class="nav-link" to="/contact">Contact</router-link>
     </div>
 </div>`;
 

--- a/portfolio/src/main/webapp/components/navheader.js
+++ b/portfolio/src/main/webapp/components/navheader.js
@@ -1,3 +1,8 @@
+/*
+ * The header at the top of every page.
+ * Has a profile picture, a name, and navigation links.
+ */
+
 const NavHeaderTemplate = 
 `<div id="header-container">
     <img id="header-img" src="./assets/me.jpg" alt="Profile picture">

--- a/portfolio/src/main/webapp/components/previewbox.js
+++ b/portfolio/src/main/webapp/components/previewbox.js
@@ -1,4 +1,4 @@
-const SimpleBoxTemplate = 
+const PreviewBoxTemplate = 
 `<div>
     <div class="preview-title">{{ title }}</div>
     <div class="preview-container">
@@ -12,9 +12,9 @@ const SimpleBoxTemplate =
     </div>
 </div>`;
 
-const SimpleBox = {
+const PreviewBox = {
     props: ['title', 'url', 'moreText'],
-    template: SimpleBoxTemplate,
+    template: PreviewBoxTemplate,
 };
 
-export { SimpleBox };
+export { PreviewBox };

--- a/portfolio/src/main/webapp/components/previewbox.js
+++ b/portfolio/src/main/webapp/components/previewbox.js
@@ -1,3 +1,9 @@
+/*
+ * A small box that "previews" the content of another page.
+ * Has a title, a small amount of content, and a link
+ * to where the rest of the content lives.
+ */
+
 const PreviewBoxTemplate = 
 `<div>
     <div class="preview-title">{{ title }}</div>

--- a/portfolio/src/main/webapp/components/simplebox.js
+++ b/portfolio/src/main/webapp/components/simplebox.js
@@ -7,7 +7,7 @@ const SimpleBoxTemplate =
         </div>
         <br/>
         <div class="preview-read-more">
-            <a :href="url"> {{ moreText }} →</a>
+            <router-link :to="url"> {{ moreText }} →</router-link>
         </div>
     </div>
 </div>`;

--- a/portfolio/src/main/webapp/components/textbox.js
+++ b/portfolio/src/main/webapp/components/textbox.js
@@ -1,0 +1,17 @@
+/*
+ * A centered box intended to contain large amounts of text.
+ * May also contain other content, such as images.
+ */
+
+const TextBoxTemplate = 
+`<div>
+    <div class="textbox">
+        <slot></slot>
+    </div>
+</div>`;
+
+const TextBox = {
+    template: TextBoxTemplate,
+};
+
+export { TextBox };

--- a/portfolio/src/main/webapp/main.js
+++ b/portfolio/src/main/webapp/main.js
@@ -1,15 +1,21 @@
 import Vue from 'https://cdn.jsdelivr.net/npm/vue@latest/dist/vue.esm.browser.min.js'
 import { Home } from './pages/home.js'
+import { About } from './pages/about.js'
 import { NavHeader } from './components/navheader.js'
 import { Footer } from './components/footer.js'
 
 Vue.use(VueRouter);
 
 // Which components to render at which endpoint
-const routes = [{
-        path: '/',
-        component: Home
-    },
+const routes = [
+  {
+    path: '/',
+    component: Home,
+  },
+  {
+    path: '/about',
+    component: About,
+  }
 ]
 
 // Inject our defined routes into VueRouter.
@@ -38,7 +44,7 @@ var app = new Vue({
     template: mainTemplate,
     data: () => {
         return {
-            msg: 'Hello'
+            msg: 'Hello',
         }
     },
 })

--- a/portfolio/src/main/webapp/pages/about.js
+++ b/portfolio/src/main/webapp/pages/about.js
@@ -10,9 +10,10 @@ const AboutTemplate =
     <h2 class="centered">About</h2>
     <br/>
 
-    <p>
+    <p class="centered">
         Hello! My name is Melanie, and I'm a sophomore at Oregon State University.
     </p>
+    <br/>
 
     <IconTitle icon="far fa-bookmark fa-2x">Studying</IconTitle>
     <ul>
@@ -39,12 +40,21 @@ const AboutTemplate =
         Alligatoah, Milky Chance, Von Wegen Lisbeth, UPSAHL, Red Royal, Nodaway
       </li>
     </ul>
+
+    <IconTitle icon="far fa-caret-square-right fa-2x">Watching</IconTitle>
+    <ul>
+      <li>
+        The Good Place, The Office, Parks and Rec, Avatar the Last Airbender,
+        The Great British Baking Show, Community, Drew Gooden, Gourmet Makes,
+        Michael Reeves, Tom Scott
+      </li>
+    </ul>
     
     <IconTitle icon="far fa-save fa-2x">Collecting</IconTitle>
     <ul>
       <li>Plants (to tend to)</li>
       <li>Glass containers (to use as tupperware)</li>
-      <li>Cardboard boxes (for virtually no reason)</li>
+      <li>Cardboard boxes ( ??? )</li>
     </ul>
   </TextBox>
 

--- a/portfolio/src/main/webapp/pages/about.js
+++ b/portfolio/src/main/webapp/pages/about.js
@@ -1,0 +1,14 @@
+const AboutTemplate = 
+`<div id="body-container">
+
+  I am an about page!
+
+</div>`;
+
+const About = {
+    template: AboutTemplate,
+    components: {
+    },
+};
+
+export { About };

--- a/portfolio/src/main/webapp/pages/about.js
+++ b/portfolio/src/main/webapp/pages/about.js
@@ -1,3 +1,7 @@
+/*
+ * The about page of the website.
+ */
+
 const AboutTemplate = 
 `<div id="body-container">
 

--- a/portfolio/src/main/webapp/pages/about.js
+++ b/portfolio/src/main/webapp/pages/about.js
@@ -6,17 +6,58 @@ const AboutTemplate =
 `<div id="body-container">
 
   <TextBox>
-    I am an about page!
+
+    <h2 class="centered">About</h2>
+    <br/>
+
+    <p>
+        Hello! My name is Melanie, and I'm a sophomore at Oregon State University.
+    </p>
+
+    <IconTitle icon="far fa-bookmark fa-2x">Studying</IconTitle>
+    <ul>
+      <li><i>Major:</i> Applied Computer Science</li>
+      <li><i>Minor:</i> Mathematics</li>
+      <li><i>Option:</i> Data Science</li>
+    </ul>
+
+    <IconTitle icon="far fa-building fa-2x">Working</IconTitle>
+    <ul>
+      <li><i>2020 Summer:</i> STEP Intern @ Google</li>
+      <li><i>2019 - Present:</i> Student Software Developer @ Center for Applied Systems and Software</li>
+    </ul>
+
+    <IconTitle icon="far fa-file-code fa-2x">Writing</IconTitle>
+    <ul>
+      <li>C# (.NET), Python, TypeScript, Vue.JS, SQL, HTML/CSS/JS</li>
+    </ul>
+
+    <IconTitle icon="far fa-dot-circle fa-2x">Listening To</IconTitle>
+    <ul>
+      <li>
+        Glass Animals, Watsky, Saint Motel, K. Flay, Caravan Palace, alt-J,
+        Alligatoah, Milky Chance, Von Wegen Lisbeth, UPSAHL, Red Royal, Nodaway
+      </li>
+    </ul>
+    
+    <IconTitle icon="far fa-save fa-2x">Collecting</IconTitle>
+    <ul>
+      <li>Plants (to tend to)</li>
+      <li>Glass containers (to use as tupperware)</li>
+      <li>Cardboard boxes (for virtually no reason)</li>
+    </ul>
   </TextBox>
 
 </div>`;
 
 import { TextBox } from '../components/textbox.js';
+import { IconTitle } from '../components/icontitle.js';
 
 const About = {
     template: AboutTemplate,
     components: {
         'TextBox': TextBox,
+        'IconTitle': IconTitle,
     },
 };
 

--- a/portfolio/src/main/webapp/pages/about.js
+++ b/portfolio/src/main/webapp/pages/about.js
@@ -5,13 +5,18 @@
 const AboutTemplate = 
 `<div id="body-container">
 
-  I am an about page!
+  <TextBox>
+    I am an about page!
+  </TextBox>
 
 </div>`;
+
+import { TextBox } from '../components/textbox.js';
 
 const About = {
     template: AboutTemplate,
     components: {
+        'TextBox': TextBox,
     },
 };
 

--- a/portfolio/src/main/webapp/pages/home.js
+++ b/portfolio/src/main/webapp/pages/home.js
@@ -1,3 +1,8 @@
+/*
+ * The home/landing page of the website.
+ * Contains preview boxes for other pages on the site.
+ */
+
 const HomeTemplate = 
 `<div id="body-container">
 

--- a/portfolio/src/main/webapp/pages/home.js
+++ b/portfolio/src/main/webapp/pages/home.js
@@ -1,35 +1,35 @@
 const HomeTemplate = 
 `<div id="body-container">
 
-  <SimpleBox title="About" url="/about" moreText="read more" >
+  <PreviewBox title="About" url="/about" moreText="read more" >
     Hello! My name is Melanie, and I'm a sophomore at Oregon State University.
-  </SimpleBox>
+  </PreviewBox>
 
-  <SimpleBox title="Projects" url="/projects" moreText="see more" >
+  <PreviewBox title="Projects" url="/projects" moreText="see more" >
     <CaptionedImage caption="Appstract (2018)" imgUrl="./assets/appstract.png">
       An artistically abstract Android icon pack. 300+ icons supported across 25+ launchers.
       Built on the open source CandyBar dashboard. Available on the Google Play Store
       <a href="https://play.google.com/store/apps/details?id=com.melon.appstract&hl=en_US">here.</a>
     </CaptionedImage>
-  </SimpleBox>
+  </PreviewBox>
 
-  <SimpleBox title="Contact" url="/contact" moreText="more ways to reach me" >
+  <PreviewBox title="Contact" url="/contact" moreText="more ways to reach me" >
     <div class="preview-icons-grid">
       <a class="icon-link" href="#"><i class="fas fa-envelope fa-3x"></i></a>
       <a class="icon-link" href="#"><i class="fab fa-linkedin-in fa-3x"></i></a>
       <a class="icon-link" href="#"><i class="fab fa-github fa-3x"></i></a>
     </div>
-  </SimpleBox>
+  </PreviewBox>
 
 </div>`;
 
-import { SimpleBox } from '../components/simplebox.js';
+import { PreviewBox } from '../components/previewbox.js';
 import { CaptionedImage } from '../components/captionedimage.js';
 
 const Home = {
     template: HomeTemplate,
     components: {
-      'SimpleBox': SimpleBox,
+      'PreviewBox': PreviewBox,
       'CaptionedImage': CaptionedImage,
     },
 };

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -41,7 +41,10 @@ a:hover{
 }
 
 #header {
+  color: #1c1c1c;
+  font-family: 'Roboto Mono', monospace;
   font-size: 40px;
+  font-weight: 600;
   flex: 1 1 100px;
   flex-shrink: 3;
   margin: 10px;
@@ -58,11 +61,8 @@ a:hover{
 
 #header-container {
   align-items: center;
-  color: #1c1c1c;
   display: flex;
   flex-wrap: wrap;
-  font-family: 'Roboto Mono', monospace;
-  font-weight: 600;
   justify-content: center;
   margin: 0px auto;
   padding: 40px 0px 0px 0px;

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -194,14 +194,14 @@ a:hover{
  */
 
 .textbox {
-border-radius: 10px;
-box-shadow: 0px 0px 48px -6px rgba(186,186,186,0.7);
--moz-box-shadow: 0px 0px 48px -6px rgba(186,186,186,0.7);
--webkit-box-shadow: 0px 0px 48px -6px rgba(186,186,186,0.7);
-font-size: 18px;
-margin: 40px auto;
-padding: 50px;
-width: 70%;
+  border-radius: 10px;
+  box-shadow: 0px 0px 48px -6px rgba(186,186,186,0.7);
+  -moz-box-shadow: 0px 0px 48px -6px rgba(186,186,186,0.7);
+  -webkit-box-shadow: 0px 0px 48px -6px rgba(186,186,186,0.7);
+  font-size: 18px;
+  margin: 40px auto;
+  padding: 50px;
+  width: 70%;
 }
 
 /*

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -80,7 +80,7 @@ a:hover{
 }
 
 /**
- ** All Preview boxes
+ ** Preview box
  **/
 
 /* The text above a preview box */
@@ -184,6 +184,20 @@ a:hover{
 }
 
 /*
+ * Textbox
+ */
+
+ .textbox {
+  border-radius: 10px;
+  box-shadow: 0px 0px 48px -6px rgba(186,186,186,0.7);
+  -moz-box-shadow: 0px 0px 48px -6px rgba(186,186,186,0.7);
+  -webkit-box-shadow: 0px 0px 48px -6px rgba(186,186,186,0.7);
+  margin: 20px auto;
+  padding: 30px;
+  width: 70%;
+ }
+
+/*
  * Responsivity (media queries)
  */
 
@@ -198,6 +212,10 @@ a:hover{
   }
   
   #header-container {
+    width: 40%;
+  }
+
+  .textbox {
     width: 40%;
   }
 }

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -21,6 +21,12 @@ a:hover{
   color: #1c1c1c;
 }
 
+.centered{
+  margin: auto;
+  width: 100%;
+  text-align: center;
+}
+
 /**
  ** Header and Nav Bar
  **/
@@ -165,12 +171,12 @@ a:hover{
  * Footer
  */
 
-#footer-container{
-  margin: 60px 0px 0px 0px;
+#footer-container {
+  margin: 30px 0px 0px 0px;
   padding: 20px 0px 30px 0px;
 }
 
-.footer-text{
+.footer-text {
   margin: 0 auto;
   text-align: center;
 }
@@ -179,7 +185,7 @@ a:hover{
  * Contact preview box
  */
 
-.icon-link{
+.icon-link {
   margin: 10px;
 }
 
@@ -187,15 +193,35 @@ a:hover{
  * Textbox
  */
 
- .textbox {
-  border-radius: 10px;
-  box-shadow: 0px 0px 48px -6px rgba(186,186,186,0.7);
-  -moz-box-shadow: 0px 0px 48px -6px rgba(186,186,186,0.7);
-  -webkit-box-shadow: 0px 0px 48px -6px rgba(186,186,186,0.7);
-  margin: 20px auto;
-  padding: 30px;
-  width: 70%;
- }
+.textbox {
+border-radius: 10px;
+box-shadow: 0px 0px 48px -6px rgba(186,186,186,0.7);
+-moz-box-shadow: 0px 0px 48px -6px rgba(186,186,186,0.7);
+-webkit-box-shadow: 0px 0px 48px -6px rgba(186,186,186,0.7);
+font-size: 18px;
+margin: 40px auto;
+padding: 50px;
+width: 70%;
+}
+
+/*
+ * Icontitle
+ */
+
+.icontitle-container {
+  align-items: center;
+  display: flex;
+}
+
+.icontitle-icon-container {
+  margin: 10px;
+  width: 40px;
+}
+
+.icontitle-icon{
+  margin: auto;
+  width: min-content;
+}
 
 /*
  * Responsivity (media queries)


### PR DESCRIPTION
Closes #2.

Added a simple `about` page to the website that uses Vue's navigation framework, `vue-router` (which provides SPA-like navigation that doesn't actually fetch another html page from the server). Created some more components that should be helpful beyond the `about page`. 

![image](https://user-images.githubusercontent.com/35010111/85780712-c2c3ed00-b6d9-11ea-9fa7-6264cdf29cd0.png)
