### PR TITLE
Add fully-functional site comments using Datastore

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -28,6 +28,11 @@
         <artifactId>gson</artifactId>
         <version>2.8.6</version>
     </dependency>
+    <dependency>
+        <groupId>com.google.appengine</groupId>
+        <artifactId>appengine-api-1.0-sdk</artifactId>
+        <version>1.9.59</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -79,10 +79,9 @@ public class DataServlet extends HttpServlet {
         String author = getParameter(request, "name", "Anonymous");
         Date datetime = new Date();
 
-        // Check for validity
-        if (!body.isEmpty()){
-            
-            // Buld the new comment
+        // Check for validity.
+        if (!body.isEmpty()) {
+            // Buld the new comment.
             Entity commentEntity = new Entity("Comment");
             commentEntity.setProperty("author", author);
             commentEntity.setProperty("body", body);

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -17,6 +17,7 @@ package com.google.sps.servlets;
 import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Date;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -27,18 +28,59 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
 
+    public class Comment {
+        String body;
+        String author;
+        Date date;
+
+        public Comment(String body, String author, Date date) {
+            this.body = body;
+            this.author = author;
+            this.date = date;
+        }
+    }
+
+    static ArrayList<Comment> comments = new ArrayList<Comment>();
+
+    /** GETs all comments stored by the server */
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        ArrayList<String> messages = new ArrayList<String>();
-        messages.add("This is the first comment!");
-        messages.add("This is the second comment!");
-        messages.add("This is the third comment!");
 
         Gson gson = new Gson();
-        String json = gson.toJson(messages);
+        String json = gson.toJson(comments);
 
         response.setContentType("text/json;");
         response.getWriter().println(json);
+    }
 
+    /** POST a new comment to the server */
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        // Get the input from the form.
+        String body = getParameter(request, "comment", "");
+        String author = getParameter(request, "name", "Anonymous");
+        Date datetime = new Date();
+
+        // Check for validity
+        if (!body.isEmpty()){
+            
+            // Buld the new comment
+            comments.add(new Comment(body, author, datetime));
+        }   
+
+        // Redirect back to the Contact page.
+        response.sendRedirect("/#/contact");
+    }
+
+    /**
+    * @return the request parameter, or the default value if the parameter
+    *         was not specified by the client
+    */
+    private String getParameter(HttpServletRequest request, String name, String defaultValue) {
+        String value = request.getParameter(name);
+        if (value == null || value.isEmpty()) {
+            return defaultValue;
+        }
+        return value;
     }
 }

--- a/portfolio/src/main/webapp/components/commentbox.js
+++ b/portfolio/src/main/webapp/components/commentbox.js
@@ -1,0 +1,19 @@
+/*
+ * A comment left by a user.
+ */
+
+const CommentBoxTemplate = 
+`<div class="commentbox-container">
+    <div class="commentbox-author"> {{ author }} </div>
+    <div class="commentbox-date"> {{ date }} UTC</div>
+    <div class="commentbox-body">
+        <slot></slot>
+    </div>
+</div>`;
+
+const CommentBox = {
+    template: CommentBoxTemplate,
+    props : ['author', 'date'],
+};
+
+export { CommentBox };

--- a/portfolio/src/main/webapp/pages/contact.js
+++ b/portfolio/src/main/webapp/pages/contact.js
@@ -32,13 +32,19 @@ const ContactTemplate =
     </TextBox>
 
     <TextBox title="Comments">
-        <p v-for="comment in comments">{{ comment }} </p>
+        <form action="/data" method="post" id="contact-form">
+            <input type="text" id="name" name="name" placeholder="Name"><br>
+            <textarea type="text" id="comment" name="comment" placeholder="Comment"></textarea>
+            <input type="submit" value="Submit">
+        </form>
+        <Comment v-for="comment in comments" :author="comment.author" :date="comment.date"> {{ comment.body }} </Comment>
     </TextBox>
     
 </div>`;
 
 import { TextBox } from '../components/textbox.js';
 import { IconTitle } from '../components/icontitle.js';
+import { CommentBox } from '../components/commentbox.js';
 
 const Contact = {
     data() {
@@ -50,10 +56,11 @@ const Contact = {
     components: {
         'TextBox': TextBox,
         'IconTitle': IconTitle,
+        'Comment': CommentBox,
     },
     async mounted() {
         // Get the comments from the server and add them to component's local state
-        this.comments = await (await fetch('/data')).json();;
+        this.comments = await (await fetch('/data')).json();
     },
 };
 

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -16,15 +16,43 @@ a {
 }
 
 a:hover{
+  color: #1c1c1c;
   text-decoration: underline rgb(195, 195, 195);
   text-decoration-thickness: 5px;
-  color: #1c1c1c;
 }
 
-.centered{
+.centered {
   margin: auto;
-  width: 100%;
   text-align: center;
+  width: 100%;
+}
+
+input,
+textarea {
+  background-color: #f7f7f7;
+  border: 0px;
+  color: gray;
+  border-radius: 5px;
+  margin: 5px 0px 5px 0px;
+  padding: 10px;
+}
+
+input:focus,
+textarea:focus {
+  color: #333333;
+  outline: none;
+}
+
+input[type=submit] {
+  color: #333333;
+}
+
+input[type=submit]:hover {
+  cursor: pointer;
+}
+
+textarea {
+  width: 100%;
 }
 
 /**
@@ -297,6 +325,37 @@ a:hover{
   justify-content: center;
   margin: 20px auto;
   width: 90%;
+}
+
+/*
+ * Commentbox
+ */
+
+#contact-form {
+  padding: 20px;
+  margin: 0px 0px 20px 0px;
+}
+
+.commentbox-container {
+  border-top: 2px solid #d0d0d0;
+  color: #333333;
+  padding: 20px;
+}
+
+.commentbox-author {
+  font-size: 17px;
+  font-weight: 700;
+}
+
+.commentbox-date { 
+  font-size: 14px;
+  margin: 2px 0px 0px 0px;
+  font-style: italic;
+}
+
+.commentbox-body {
+  font-size: 17px;
+  margin: 10px 0px 0px 0px;
 }
 
 /*

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -31,9 +31,9 @@ input,
 textarea {
   background-color: #f7f7f7;
   border: 0px;
-  color: gray;
   border-radius: 5px;
-  margin: 5px 0px 5px 0px;
+  color: gray;
+  margin: 5px 0px;
   padding: 10px;
 }
 


### PR DESCRIPTION
Closes #14.

Adds fully functional comments to the website (Contact page). Comments are stored using Datastore, and persist across deployments.

Simple server-side validation ensures that no empty comments are submitted, and comments without authors are submitted as 'Anonymous'.

![Screenshot 2020-06-29 at 4 09 28 PM](https://user-images.githubusercontent.com/35010111/86064861-f6c54800-ba22-11ea-8d79-66001a844567.png)
