### PR TITLE
Add limits to the number of comments and instant comments (no refresh)

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -53,11 +53,14 @@ public class DataServlet extends HttpServlet {
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
 
         // Get the input from the form.
-        int numberOfCommentsToShow = 10;
+        int numberOfCommentsToShow;
         if (request.getParameter("num-comments") != null && !request.getParameter("num-comments").isEmpty()){
             try {
                 numberOfCommentsToShow = Integer.parseInt(request.getParameter("num-comments"));
-            } catch (Exception e) {}
+            } catch (Exception e) {
+                // If parsing fails (non-numeric input), we silently fall back on showing 10 comments
+                numberOfCommentsToShow = 10;
+            }
         }
 
         Query query = new Query("Comment").addSort("datetime", SortDirection.DESCENDING);

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -32,7 +32,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 
-/** Servlet that returns some example content. TODO: modify this file to handle comments data */
+/** Servlet that allows the client to create and read comments */
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
 
@@ -48,7 +48,7 @@ public class DataServlet extends HttpServlet {
         }
     }
 
-    /** GETs a user-defined number of comments stored by the server */
+    /** GETs a user-defined number of comments stored by the server. */
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
 
@@ -82,7 +82,7 @@ public class DataServlet extends HttpServlet {
         response.getWriter().println(json);
     }
 
-    /** POST a new comment to the server */
+    /** POST a new comment to the server. */
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
 
@@ -109,7 +109,7 @@ public class DataServlet extends HttpServlet {
 
     /**
     * @return the request parameter, or the default value if the parameter
-    *         was not specified by the client
+    *         was not specified by the client.
     */
     private String getParameter(HttpServletRequest request, String name, String defaultValue) {
         String value = request.getParameter(name);

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -85,10 +85,13 @@ public class DataServlet extends HttpServlet {
     /** POST a new comment to the server */
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+
         // Get the input from the form.
-        String body = getParameter(request, "comment", "");
-        String author = getParameter(request, "name", "Anonymous");
+        String body = getParameter(request, "body", "");
+        String author = getParameter(request, "author", "Anonymous");
         Date datetime = new Date();
+
+        System.out.println("Got body: " + body + " Author: " + author);
 
         // Check for validity
         if (!body.isEmpty()){
@@ -101,7 +104,7 @@ public class DataServlet extends HttpServlet {
 
             DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
             datastore.put(commentEntity);
-        }   
+        }
 
         // Redirect back to the Contact page.
         response.sendRedirect("/#/contact");

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -30,12 +30,9 @@
 
     <!--CDN imports-->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/vue-router/3.0.2/vue-router.js"></script>
-    <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
 
     <!--Entry point that binds Vue to the div above-->
     <script type="module" src="vueapp.js"></script>
-
-
 
 </body>
 

--- a/portfolio/src/main/webapp/pages/contact.js
+++ b/portfolio/src/main/webapp/pages/contact.js
@@ -32,6 +32,16 @@ const ContactTemplate =
     </TextBox>
 
     <TextBox title="Comments">
+        <form action="">
+            <label>Number of results:</label>
+            <select v-model="numComments" id="num-comments" name="num-comments">
+                <option value="5">5</option>
+                <option value="10">10</option>
+                <option value="25">25</option>
+                <option value="50">50</option>
+                <option value="-1">all</option>
+            </select>
+        </form>
         <form action="/data" method="post" id="contact-form">
             <input type="text" id="name" name="name" placeholder="Name"><br>
             <textarea type="text" id="comment" name="comment" placeholder="Comment"></textarea>
@@ -50,6 +60,7 @@ const Contact = {
     data() {
         return {
             comments: [],
+            numComments: 10,
         }
     },
     template: ContactTemplate,
@@ -62,6 +73,13 @@ const Contact = {
         // Get the comments from the server and add them to component's local state
         this.comments = await (await fetch('/data')).json();
     },
+    watch: {
+        // When the user picks a new number of comments, replace the comments with the new ones
+        async numComments(newNum, oldNum) {
+            console.log("I changed!")
+            this.comments = await (await fetch('/data?num-comments=' + newNum)).json();
+        }
+    }
 };
 
 export { Contact };

--- a/portfolio/src/main/webapp/pages/contact.js
+++ b/portfolio/src/main/webapp/pages/contact.js
@@ -48,7 +48,9 @@ const ContactTemplate =
             <option value="-1">all</option>
         </select>
         </form>
-        <Comment v-for="comment in comments" :author="comment.author" :date="comment.date" :class="{ greyed: comment.greyed }"> {{ comment.body }} </Comment>
+        <Comment v-for="comment in comments" :author="comment.author" :date="comment.date" :class="{ greyed: comment.greyed }">
+            {{ comment.body }}
+        </Comment>
     </TextBox>
     
 </div>`;
@@ -103,11 +105,13 @@ const Contact = {
                 body: vueInstance.createSearchParamsFromObject(this.commentDraft)
             }).then(function (response) {
                 if (!response.ok) {
-                    vueInstance.removeLastCommentAndShowMessage("The server encountered an error while trying to add your comment.");
+                    vueInstance.removeLastCommentAndShowMessage(
+                        "The server encountered an error while trying to add your comment.");
                     return;
                 } 
             }).catch(function (err) {
-		        vueInstance.removeLastCommentAndShowMessage("The server encountered the following error while trying to add your comment: " + err);
+		        vueInstance.removeLastCommentAndShowMessage(
+                    "The server encountered the following error while trying to add your comment: " + err);
                 return;
             });
 

--- a/portfolio/src/main/webapp/pages/contact.js
+++ b/portfolio/src/main/webapp/pages/contact.js
@@ -40,7 +40,7 @@ const ContactTemplate =
         <div v-if="this.error.length > 0" id="error-bar"> {{ error }} </div>
         <form id="num-comments-form">
         <label id="num-comments-label">Number of results:</label>
-        <select v-model="numComments" id="num-comments" name="num-comments">
+        <select v-model="numCommentsToShow" id="num-comments" name="num-comments">
             <option value="5">5</option>
             <option value="10">10</option>
             <option value="25">25</option>
@@ -63,7 +63,7 @@ const Contact = {
     data() {
         return {
             comments: [],
-            numComments: 10,
+            numCommentsToShow: 10,
             commentDraft: {
                 author: "",
                 body: "",
@@ -135,12 +135,10 @@ const Contact = {
             comment.date = new Date().toLocaleDateString("en-US", { year: 'numeric', month: 'short', day: 'numeric', 
                                                                     hour: 'numeric', minute: 'numeric', second: 'numeric' });
             this.comments.unshift(Object.assign({}, comment));
-            this.numComments++;
         },
         // Removes the local comment that was most recently added, and displays an error message
         removeLastCommentAndShowMessage(msg){
             this.comments.splice(0, 1);
-            this.numComments--;
             this.error = msg;
             return;
         }
@@ -151,7 +149,7 @@ const Contact = {
     },
     watch: {
         // When the user picks a new number of comments, adjust the list to show that many
-        async numComments(newNum, oldNum) {
+        async numCommentsToShow(newNum, oldNum) {
             let castNewNum = Number(newNum);
             let castOldNum = Number(oldNum);
 

--- a/portfolio/src/main/webapp/pages/contact.js
+++ b/portfolio/src/main/webapp/pages/contact.js
@@ -32,20 +32,20 @@ const ContactTemplate =
     </TextBox>
 
     <TextBox title="Comments">
-        <form action="">
-            <label>Number of results:</label>
-            <select v-model="numComments" id="num-comments" name="num-comments">
-                <option value="5">5</option>
-                <option value="10">10</option>
-                <option value="25">25</option>
-                <option value="50">50</option>
-                <option value="-1">all</option>
-            </select>
-        </form>
         <form action="/data" method="post" id="contact-form">
             <input type="text" id="name" name="name" placeholder="Name"><br>
             <textarea type="text" id="comment" name="comment" placeholder="Comment"></textarea>
             <input type="submit" value="Submit">
+        </form>
+        <form id="num-comments-form">
+        <label id="num-comments-label">Number of results:</label>
+        <select v-model="numComments" id="num-comments" name="num-comments">
+            <option value="5">5</option>
+            <option value="10">10</option>
+            <option value="25">25</option>
+            <option value="50">50</option>
+            <option value="-1">all</option>
+        </select>
         </form>
         <Comment v-for="comment in comments" :author="comment.author" :date="comment.date"> {{ comment.body }} </Comment>
     </TextBox>
@@ -76,7 +76,6 @@ const Contact = {
     watch: {
         // When the user picks a new number of comments, replace the comments with the new ones
         async numComments(newNum, oldNum) {
-            console.log("I changed!")
             this.comments = await (await fetch('/data?num-comments=' + newNum)).json();
         }
     }

--- a/portfolio/src/main/webapp/pages/contact.js
+++ b/portfolio/src/main/webapp/pages/contact.js
@@ -6,7 +6,7 @@ const ContactTemplate =
 `<div id="body-container">
 
     <TextBox title="Get in Touch">
-        <div class="icontitle-group">
+        <div class="icontitle-group" id="contact-group">
             
             <a class="icon-link" href="mailto:mirrorkeydev@gmail.com">
                 <IconTitle icon="fas fa-envelope fa-2x">mirrorkeydev@gmail.com</IconTitle>

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -332,7 +332,7 @@ textarea {
  */
 
 .commentbox-container {
-  border-top: 2px solid #d0d0d0;
+  border-top: 1px solid #d0d0d0;
   color: #333333;
   padding: 20px;
 }
@@ -395,7 +395,6 @@ textarea {
     margin: 50px 0px 0px 30%;
   }
   
-  
   .preview-container {
     width: 40%;
   }
@@ -416,4 +415,7 @@ textarea {
     font-size: 15px;
   }
 
+  #contact-group {
+    font-size: 14px;
+  }
 }

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -55,6 +55,10 @@ textarea {
   width: 100%;
 }
 
+.greyed {
+  color: #bcbcbc;
+}
+
 /**
  ** Header and Nav Bar
  **/
@@ -226,6 +230,7 @@ textarea {
   box-shadow: 0px 0px 48px -6px rgba(186,186,186,0.7);
   -moz-box-shadow: 0px 0px 48px -6px rgba(186,186,186,0.7);
   -webkit-box-shadow: 0px 0px 48px -6px rgba(186,186,186,0.7);
+  color: #333333;
   font-size: 18px;
   margin: 20px auto;
   padding: 30px;
@@ -333,8 +338,7 @@ textarea {
 
 .commentbox-container {
   border-top: 1px solid #d0d0d0;
-  color: #333333;
-  padding: 20px;
+padding: 20px;
 }
 
 .commentbox-author {
@@ -379,6 +383,16 @@ textarea {
   font-size: 13px;
   outline: none;
   padding: 5px;
+}
+
+#error-bar {
+  background-color: #ffdbdb;
+  border-radius: 5px;
+  color: #9a2929;
+  font-size: 16px;
+  margin: 10px 20px;
+  padding: 10px;
+  text-align: center;
 }
 
 /*

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -338,7 +338,7 @@ textarea {
 
 .commentbox-container {
   border-top: 1px solid #d0d0d0;
-padding: 20px;
+  padding: 20px;
 }
 
 .commentbox-author {

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -331,11 +331,6 @@ textarea {
  * Commentbox
  */
 
-#contact-form {
-  padding: 20px;
-  margin: 0px 0px 20px 0px;
-}
-
 .commentbox-container {
   border-top: 2px solid #d0d0d0;
   color: #333333;
@@ -356,6 +351,34 @@ textarea {
 .commentbox-body {
   font-size: 17px;
   margin: 10px 0px 0px 0px;
+}
+
+/*
+ * Contact page (contact.js)
+ */
+
+#contact-form {
+  padding: 20px 20px 0px 20px;
+}
+
+#num-comments-form {
+  padding: 0px 20px 20px 20px;
+  text-align: right;
+}
+
+#num-comments-label {
+  color: #3c3c3c;
+  font-size: 15px;
+  margin: 0px 5px 0px 0px;
+}
+
+#num-comments {
+  background-color: #f7f7f7;
+  border: none;
+  color: #333333;
+  font-size: 13px;
+  outline: none;
+  padding: 5px;
 }
 
 /*


### PR DESCRIPTION
#### Comment number limits
There is now a dropdown with which you can choose how many comments you want to display. If you are requesting more comments than are currently displayed, then it sends a new request to the server. If you are requesting less comments, it leaves the server alone and just shows you less of the cached content.
#### Instant comments
When you add a comment, it doesn't refresh the page. Instead, it instantly adds the new comment below the input box, where it remains slightly greyed out. Meanwhile in the background, a request is sent to the server to add the comment, and if it succeeds, the comment is un-greyed. If it fails, the comment is removed and an error is shown.

![8](https://user-images.githubusercontent.com/35010111/91586562-6a43e280-e90a-11ea-995f-8908e785da0e.gif)

#### Error handling
I have done my best to make the comments section fault tolerant. In all these cases, this is what the page does:
- Server returns non-200: show error
- Network goes down: show error
- Comment without body: show error with suggestion to write something
- A packet is sent with comment data that the frontend doesn't allow you to input (e.g. empty comment): comment is silently denied
- Comment without name: name is submitted as "Anonymous"

[Deployed here](https://gutzmann-step-2020.uc.r.appspot.com/#/contact)
![image](https://user-images.githubusercontent.com/35010111/91586915-eb9b7500-e90a-11ea-8f93-9683363b4439.png)
