### PR TITLE
Add feature to view comments in multiple languages

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -18,21 +18,26 @@
 
   <dependencies>
     <dependency>
-        <groupId>javax.servlet</groupId>
-        <artifactId>javax.servlet-api</artifactId>
-        <version>4.0.1</version>
-        <scope>provided</scope>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>4.0.1</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
-        <groupId>com.google.code.gson</groupId>
-        <artifactId>gson</artifactId>
-        <version>2.8.6</version>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.6</version>
     </dependency>
     <dependency>
-        <groupId>com.google.appengine</groupId>
-        <artifactId>appengine-api-1.0-sdk</artifactId>
-        <version>1.9.59</version>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-1.0-sdk</artifactId>
+      <version>1.9.59</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-translate</artifactId>
+      <version>1.70.0</version>
+      </dependency>
   </dependencies>
 
   <build>

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
@@ -40,6 +40,7 @@ public class DeleteDataServlet extends HttpServlet {
     /** Deletes all comments. */
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        System.out.println("Deleting all comments");
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
         PreparedQuery results = datastore.prepare(new Query("Comment"));
         ArrayList<Key> keys = new ArrayList<Key>();

--- a/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DeleteDataServlet.java
@@ -40,7 +40,6 @@ public class DeleteDataServlet extends HttpServlet {
     /** Deletes all comments. */
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        System.out.println("Deleting all comments");
         DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
         PreparedQuery results = datastore.prepare(new Query("Comment"));
         ArrayList<Key> keys = new ArrayList<Key>();

--- a/portfolio/src/main/webapp/pages/contact.js
+++ b/portfolio/src/main/webapp/pages/contact.js
@@ -37,7 +37,7 @@ const ContactTemplate =
     </div>
   </TextBox>
 
-  <TextBox :title="this.comments.length + ' Comment' + (this.comments.length != 1 ? 's' : '')">
+  <TextBox :title="this.serverNumComments + ' Comment' + (this.serverNumComments != 1 ? 's' : '')">
     <form @submit.prevent="addNewComment" id="contact-form">
       <input type="text" id="name" name="name" placeholder="Name"
         autocomplete="off" v-model="commentDraft.author"><br>
@@ -47,17 +47,31 @@ const ContactTemplate =
       <input type="submit" value="Submit">
     </form>
     <div v-if="this.error.length > 0" id="error-bar"> {{ error }} </div>
-    <form id="num-comments-form">
-    <label v-if="this.comments.length > 0" id="num-comments-label">Number of results:</label>
-    <select v-if="this.comments.length > 0" v-model="numCommentsToShow"
-        id="num-comments" name="num-comments">
-      <option value="5">5</option>
-      <option value="10">10</option>
-      <option value="25">25</option>
-      <option value="50">50</option>
-      <option value="-1">all</option>
-    </select>
-    </form>
+    <div id="num-comments-form">
+      <label v-if="this.comments.length > 0" id="num-comments-label">Language:</label>
+      <select v-if="this.comments.length > 0" v-model="commentLangToShow"
+          id="lang-comments" name="lang-comments">
+        <option value="ar">Arabic</option>
+        <option value="bn">Bengali</option>
+        <option value="zh">Chinese</option>
+        <option value="en">English</option>
+        <option value="de">German</option>
+        <option value="hi">Hindi</option>
+        <option value="ja">Japanese</option>
+        <option value="pt">Portuguese</option>
+        <option value="ru">Russian</option>
+        <option value="es">Spanish</option>
+      </select>
+      <label v-if="this.comments.length > 0" id="num-comments-label">Number of results:</label>
+      <select v-if="this.comments.length > 0" v-model="numCommentsToShow"
+          id="num-comments" name="num-comments">
+        <option value="5">5</option>
+        <option value="10">10</option>
+        <option value="25">25</option>
+        <option value="50">50</option>
+        <option value="-1">all</option>s
+      </select>
+    </div>
     <Comment v-for="comment in comments" :author="comment.author" 
       :date="comment.date" :class="{ greyed: comment.greyed }">
       {{ comment.body }}
@@ -82,15 +96,24 @@ import {TextBox} from '../components/textbox.js';
 const Contact = {
   data() {
     return {
+      // The comments that the user sees.
       comments: [],
-      numCommentsToShow: 10,
+      // The number of comments the user sees, dropdown defined.
+      numCommentsToShow: -1,
+      // The language to which to translate the comments, dropdown defined.
+      commentLangToShow: 'en',
+      // The total number of comments existing in the Datastore.
+      serverNumComments: 0,
+      // The comment that the user drafts in the text input fields.
       commentDraft: {
         author: '',
         body: '',
         date: Date.now(),
         greyed: false,
       },
+      // Any errors that occur while saving the user's comment.
       error: '',
+      // Whether or not the confirmation modal is displayed.
       modalActive: false,
     };
   },
@@ -159,10 +182,12 @@ const Contact = {
             hour: 'numeric', minute: 'numeric', second: 'numeric',
           });
       this.comments.unshift(Object.assign({}, comment));
+      this.serverNumComments++;
     },
     // Removes the local comment that was most recently added.
     removeLastComment() {
       this.comments.splice(0, 1);
+      this.serverNumComments--;
     },
     // Opens the "are you sure?" modal.
     showConfirmationModal() {
@@ -184,12 +209,14 @@ const Contact = {
       }
 
       // Refresh the comments that the user sees
-      this.comments = await (await fetch('/data')).json();
+      this.comments = await (await fetch('/data?num-comments=' + this.numCommentsToShow)).json();
+      this.serverNumComments = 0;
     },
   },
   async mounted() {
     // Get the comments from the server and add them to component's local state
-    this.comments = await (await fetch('/data')).json();
+    this.comments = await (await fetch('/data?num-comments=-1')).json();
+    this.serverNumComments = this.comments.length;
   },
   watch: {
     // When the user picks a new number of comments, adjust the list to show that many
@@ -206,6 +233,10 @@ const Contact = {
         // so just show them the first n comments
         this.comments = this.comments.slice(0, castNewNum);
       }
+    },
+    // When the user picks a new comment language, rerun the comment query to show them
+    async commentLangToShow(newLang, oldLang) {
+      console.log('did thing!');
     },
   },
 };

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -68,6 +68,21 @@ input[type=submit]:hover {
   -webkit-filter: blur(5px);
 }
 
+select {
+  background-color: #f7f7f7;
+  border: none;
+  color: #333;
+  font-size: 13px;
+  outline: none;
+  padding: 5px;
+}
+
+label {
+  color: #3c3c3c;
+  font-size: 15px;
+  margin: 0 5px;
+}
+
 /**
  ** Header and Nav Bar
  **/
@@ -433,21 +448,6 @@ input[type=submit]:hover {
 #num-comments-form {
   padding: 0 20px 20px 20px;
   text-align: right;
-}
-
-#num-comments-label {
-  color: #3c3c3c;
-  font-size: 15px;
-  margin: 0 5px 0 0;
-}
-
-#num-comments {
-  background-color: #f7f7f7;
-  border: none;
-  color: #333;
-  font-size: 13px;
-  outline: none;
-  padding: 5px;
 }
 
 #error-bar {


### PR DESCRIPTION
Allows users to select the language they would like to view comments in, which are then dynamically reloaded with content produced by running them through Google's translation engine.

Also some small bug fixes.

![image](https://user-images.githubusercontent.com/35010111/86649505-ac017e00-bf96-11ea-9340-321af29d216e.png)
