### PR TITLE
Add the ability for optional attendees

### DIFF
--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -116,14 +116,14 @@ public final class FindMeetingQuery {
     ArrayList<TimeRange> compatibleRanges = new ArrayList<>();
     int lastRangeDuration = 0;
 
-    // Start testing start times, slowly incrementing the range from a given start until it's
-    // invalid.
+    // Start testing start times, slowly incrementing the range from a given start until the
+    // range becomes invalid (because it conflicts with someone's calendar).
     for (int i = TimeRange.START_OF_DAY; i <= INCLUSIVE_END_OF_DAY; i += lastRangeDuration) {
 
       TimeRange lastSuccessfulProposedRange = null;
 
-      // Every iteration, we "append" GRANULARITYmin to the last proposed range and see if it's
-      // still valid.
+      // Every iteration, we "append" GRANULARITY min. to the last proposed range and see if 
+      // it's still valid.
       for (int j = GRANULARITY; j + i <= INCLUSIVE_END_OF_DAY; j += GRANULARITY) {
 
         // Increase the last proposedRange by GRANULARITY minutes.

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -22,61 +22,53 @@ import java.util.Set;
 public final class FindMeetingQuery {
 
   public final int INCLUSIVE_END_OF_DAY = TimeRange.END_OF_DAY + 1;
+  public final int GRANULARITY = 5;
 
   /**
    * Returns the timeranges >= the proposed meeting length for which all attendees are free to
    * attend.
+   *
+   * @param events all registered events, possibly including some for people we don't care about.
+   * @param request the request for a new meeting, including the attendees and duration.
    */
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
 
     // Get all attendees invited to this new event.
-    Collection<String> attendees = request.getAttendees();
+    Collection<String> mandatoryAttendees = request.getAttendees();
+    Collection<String> optionalAttendees = request.getOptionalAttendees();
+    Collection<String> allAttendees = new ArrayList<String>();
+    allAttendees.addAll(optionalAttendees);
+    allAttendees.addAll(mandatoryAttendees);
 
     // For each attendee, get all other events they are involved with.
-    HashMap<String, ArrayList<Event>> attendeesEvents = getEventsWithAttendees(events, attendees);
+    HashMap<String, ArrayList<Event>> attendeesEvents = getEventsWithAttendees(events, allAttendees);
 
-    ArrayList<TimeRange> compatibleRanges = new ArrayList<>();
-    int lastRangeDuration = 0;
+    // Calculate the time ranges as if everyone was mandatory, just to see if there exists a "best case".
+    ArrayList<TimeRange>  compatibleRangesForAllAttendees = findTimeRangesForAttendees(allAttendees, attendeesEvents, (int) request.getDuration());
 
-    // Start testing start times, slowly incrementing the range from a given start until it's
-    // invalid.
-    for (int i = TimeRange.START_OF_DAY; i <= INCLUSIVE_END_OF_DAY; i += lastRangeDuration) {
-
-      TimeRange lastSuccessfulProposedRange = null;
-
-      // Every iteration, we "append" 30min to the last proposed range and see if it's still valid.
-      for (int j = 30; j + i <= INCLUSIVE_END_OF_DAY; j += 30) {
-
-        // Increase the last proposedRange by 30 minutes.
-        TimeRange proposedRange = TimeRange.fromStartDuration(i, j);
-
-        // Check if the new proposedRange works for everyone.
-        if (noAttendeesHaveConflictWithTime(attendees, attendeesEvents, proposedRange)) {
-          lastSuccessfulProposedRange = proposedRange;
-        } else {
-          break;
-        }
-      }
-
-      // If we managed to set lastSuccessfulProposedRange and it's at least as long as was
-      // requested, then it's a timerange in which nobody has conflicts and fits the request,
-      // so we add it to our final tally.
-      if (lastSuccessfulProposedRange != null
-          && lastSuccessfulProposedRange.duration() >= (int) request.getDuration()) {
-        compatibleRanges.add(lastSuccessfulProposedRange);
-      }
-
-      // Increment the tested startTime by the time of the last successfully proposed range (or the
-      // default 30 minutes).
-      lastRangeDuration =
-          lastSuccessfulProposedRange != null ? lastSuccessfulProposedRange.duration() : 30;
+    // Calculate time ranges for mandatory attendees, but only if there are any - if there aren't,
+    // we treat all optional attendees as mandatory since there's no distinction anymore.
+    ArrayList<TimeRange> compatibleRangesForMandatoryAttendeesOnly = new ArrayList<>();
+    if (mandatoryAttendees.size() > 0) {
+      compatibleRangesForMandatoryAttendeesOnly = findTimeRangesForAttendees(mandatoryAttendees, attendeesEvents, (int) request.getDuration());
     }
 
-    // Return the final list of all ranges that are compatible with attendees' calendars.
-    return compatibleRanges;
+    // If pretending everyone was mandatory (including optional attendees) didn't work (no results), 
+    // then only use the ranges that actually correspond with the mandatory attendees.
+    if (compatibleRangesForAllAttendees.size() == 0) {
+      return compatibleRangesForMandatoryAttendeesOnly;
+    }
+    else {
+      return compatibleRangesForAllAttendees;
+    }
   }
 
-  /** Gets all events that the given attendees are a part of. */
+  /** 
+   * Gets all events that the given attendees are a part of.
+   *
+   * @param events all events, possibly including some for people we don't care about.
+   * @param attendees the attendees we care about getting events for.
+   */
   public HashMap<String, ArrayList<Event>> getEventsWithAttendees(
       Collection<Event> events, Collection<String> attendees) {
 
@@ -106,8 +98,64 @@ public final class FindMeetingQuery {
   }
 
   /**
+   * Given a list of attendees, find all time ranges that fit with their event calendars.
+   *
+   * @param attendees all attendees to consider when looking for time ranges.
+   * @param attendeesEvents all events associated with each attendee.
+   * @param proposedMeetingDuration the proposed duration of the meeting.
+   */
+  public ArrayList<TimeRange> findTimeRangesForAttendees(
+      Collection<String> attendees,
+      HashMap<String, ArrayList<Event>> attendeesEvents,
+      int proposedMeetingDuration) {
+
+    ArrayList<TimeRange> compatibleRanges = new ArrayList<>();
+    int lastRangeDuration = 0;
+
+    // Start testing start times, slowly incrementing the range from a given start until it's
+    // invalid.
+    for (int i = TimeRange.START_OF_DAY; i <= INCLUSIVE_END_OF_DAY; i += lastRangeDuration) {
+
+      TimeRange lastSuccessfulProposedRange = null;
+
+      // Every iteration, we "append" GRANULARITYmin to the last proposed range and see if it's still valid.
+      for (int j = GRANULARITY; j + i <= INCLUSIVE_END_OF_DAY; j += GRANULARITY) {
+
+        // Increase the last proposedRange by GRANULARITY minutes.
+        TimeRange proposedRange = TimeRange.fromStartDuration(i, j);
+
+        // Check if the new proposedRange works for everyone.
+        if (noAttendeesHaveConflictWithTime(attendees, attendeesEvents, proposedRange)) {
+          lastSuccessfulProposedRange = proposedRange;
+        } else {
+          break;
+        }
+      }
+
+      // If we managed to set lastSuccessfulProposedRange and it's at least as long as was
+      // requested, then it's a timerange in which nobody has conflicts and fits the request,
+      // so we add it to our final tally.
+      if (lastSuccessfulProposedRange != null
+          && lastSuccessfulProposedRange.duration() >= proposedMeetingDuration) {
+        compatibleRanges.add(lastSuccessfulProposedRange);
+      }
+
+      // Increment the tested startTime by the time of the last successfully proposed range (or the
+      // default GRANULARITY minutes).
+      lastRangeDuration =
+          lastSuccessfulProposedRange != null ? lastSuccessfulProposedRange.duration() : GRANULARITY;
+    }
+
+    return compatibleRanges;
+  }
+
+  /**
    * Returns true if none of the given attendees have a time conflict with the proposed time range,
    * false otherwise.
+   *
+   * @param attendees all attendees to check time conflicts against.
+   * @param attendeesEvents all events associated with each attendee.
+   * @param proposedRange the proposed time range to check for conflict.
    */
   public boolean noAttendeesHaveConflictWithTime(
       Collection<String> attendees,

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -122,7 +122,7 @@ public final class FindMeetingQuery {
 
       TimeRange lastSuccessfulProposedRange = null;
 
-      // Every iteration, we "append" GRANULARITY min. to the last proposed range and see if 
+      // Every iteration, we "append" GRANULARITY min. to the last proposed range and see if
       // it's still valid.
       for (int j = GRANULARITY; j + i <= INCLUSIVE_END_OF_DAY; j += GRANULARITY) {
 

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -41,29 +41,33 @@ public final class FindMeetingQuery {
     allAttendees.addAll(mandatoryAttendees);
 
     // For each attendee, get all other events they are involved with.
-    HashMap<String, ArrayList<Event>> attendeesEvents = getEventsWithAttendees(events, allAttendees);
+    HashMap<String, ArrayList<Event>> attendeesEvents =
+        getEventsWithAttendees(events, allAttendees);
 
-    // Calculate the time ranges as if everyone was mandatory, just to see if there exists a "best case".
-    ArrayList<TimeRange>  compatibleRangesForAllAttendees = findTimeRangesForAttendees(allAttendees, attendeesEvents, (int) request.getDuration());
+    // Calculate the time ranges as if everyone was mandatory, just to see if there exists a "best
+    // case".
+    ArrayList<TimeRange> compatibleRangesForAllAttendees =
+        findTimeRangesForAttendees(allAttendees, attendeesEvents, (int) request.getDuration());
 
     // Calculate time ranges for mandatory attendees, but only if there are any - if there aren't,
     // we treat all optional attendees as mandatory since there's no distinction anymore.
     ArrayList<TimeRange> compatibleRangesForMandatoryAttendeesOnly = new ArrayList<>();
     if (mandatoryAttendees.size() > 0) {
-      compatibleRangesForMandatoryAttendeesOnly = findTimeRangesForAttendees(mandatoryAttendees, attendeesEvents, (int) request.getDuration());
+      compatibleRangesForMandatoryAttendeesOnly =
+          findTimeRangesForAttendees(
+              mandatoryAttendees, attendeesEvents, (int) request.getDuration());
     }
 
-    // If pretending everyone was mandatory (including optional attendees) didn't work (no results), 
+    // If pretending everyone was mandatory (including optional attendees) didn't work (no results),
     // then only use the ranges that actually correspond with the mandatory attendees.
     if (compatibleRangesForAllAttendees.size() == 0) {
       return compatibleRangesForMandatoryAttendeesOnly;
-    }
-    else {
+    } else {
       return compatibleRangesForAllAttendees;
     }
   }
 
-  /** 
+  /**
    * Gets all events that the given attendees are a part of.
    *
    * @param events all events, possibly including some for people we don't care about.
@@ -118,7 +122,8 @@ public final class FindMeetingQuery {
 
       TimeRange lastSuccessfulProposedRange = null;
 
-      // Every iteration, we "append" GRANULARITYmin to the last proposed range and see if it's still valid.
+      // Every iteration, we "append" GRANULARITYmin to the last proposed range and see if it's
+      // still valid.
       for (int j = GRANULARITY; j + i <= INCLUSIVE_END_OF_DAY; j += GRANULARITY) {
 
         // Increase the last proposedRange by GRANULARITY minutes.
@@ -143,7 +148,9 @@ public final class FindMeetingQuery {
       // Increment the tested startTime by the time of the last successfully proposed range (or the
       // default GRANULARITY minutes).
       lastRangeDuration =
-          lastSuccessfulProposedRange != null ? lastSuccessfulProposedRange.duration() : GRANULARITY;
+          lastSuccessfulProposedRange != null
+              ? lastSuccessfulProposedRange.duration()
+              : GRANULARITY;
     }
 
     return compatibleRanges;

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -32,14 +32,19 @@ public final class FindMeetingQueryTest {
   // Some people that we can use in our tests.
   private static final String PERSON_A = "Person A";
   private static final String PERSON_B = "Person B";
+  private static final String PERSON_C = "Person C";
 
   // All dates are the first day of the year 2020.
   private static final int TIME_0800AM = TimeRange.getTimeInMinutes(8, 0);
   private static final int TIME_0830AM = TimeRange.getTimeInMinutes(8, 30);
+  private static final int TIME_0845AM = TimeRange.getTimeInMinutes(8, 45);
   private static final int TIME_0900AM = TimeRange.getTimeInMinutes(9, 0);
   private static final int TIME_0930AM = TimeRange.getTimeInMinutes(9, 30);
   private static final int TIME_1000AM = TimeRange.getTimeInMinutes(10, 0);
   private static final int TIME_1100AM = TimeRange.getTimeInMinutes(11, 00);
+  private static final int TIME_0100PM = TimeRange.getTimeInMinutes(13, 00);
+  private static final int TIME_0230PM = TimeRange.getTimeInMinutes(14, 30);
+  private static final int TIME_0300PM = TimeRange.getTimeInMinutes(15, 00);
 
   private static final int DURATION_30_MINUTES = 30;
   private static final int DURATION_60_MINUTES = 60;
@@ -305,6 +310,199 @@ public final class FindMeetingQueryTest {
                 Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_60_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected = Arrays.asList();
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void optionalAttendeesAreIgnoredIfConflicting() {
+    // Have each person have different events, with an optional attendee, C, in an all-day event.
+    // Options return events as if C wasn't invited.
+    //
+    // Events  :       |--A--|     |--B--|
+    //         : |--------------C*-------------| (* optional)
+    // Day     : |-----------------------------|
+    // Options : |--1--|     |--2--|     |--3--|
+
+    Collection<Event> events =
+        Arrays.asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_B)),
+            new Event(
+                "Event 3",
+                TimeRange.fromStartDuration(TimeRange.START_OF_DAY, TimeRange.WHOLE_DAY.duration()),
+                Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void optionalAttendeesAreIncludedIfPossible() {
+    // Have each person have different events. We should see two options because each person has
+    // split the restricted times.
+    //
+    // Events  :       |--A--|     |--B--|
+    //         :             |--C*-|             (*optional)
+    // Day     : |-----------------------------|
+    // Options : |--1--|                 |--3--|
+
+    Collection<Event> events =
+        Arrays.asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_B)),
+            new Event(
+                "Event 3",
+                TimeRange.fromStartDuration(TIME_0830AM, TIME_0900AM),
+                Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void justEnoughRoomWithOptionalAttendee() {
+    // Request a 30 minute meeting but ignore the optional attendee because the only option
+    // would encroach on their schedule.
+    //
+    // Events  : |--A--|      |----A----|
+    //         :       |B*|              (*optional)
+    // Day     : |----------------------|
+    // Options :       |-----|
+
+    Collection<Event> events =
+        Arrays.asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 3",
+                TimeRange.fromStartEnd(TIME_0830AM, TIME_0845AM, false),
+                Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void onlyOptionalAttendeesWithGaps() {
+    // Only have optional attendees, no mandatory ones, and there are gaps in their schedule.
+    //
+    // Events  :    |--A*-|        |--A*-|
+    //         :       |--B*-|     |---B*--|     (*optional)
+    // Day     : |------------------------------|
+    // Options : |--|        |-----|       |----|
+
+    Collection<Event> events =
+        Arrays.asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartEnd(TIME_0830AM, TIME_0930AM, false),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartEnd(TIME_0900AM, TIME_1000AM, false),
+                Arrays.asList(PERSON_B)),
+            new Event(
+                "Event 3",
+                TimeRange.fromStartEnd(TIME_0100PM, TIME_0230PM, false),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 4",
+                TimeRange.fromStartEnd(TIME_0100PM, TIME_0300PM, false),
+                Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            TimeRange.fromStartEnd(TIME_1000AM, TIME_0100PM, false),
+            TimeRange.fromStartEnd(TIME_0300PM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void onlyOptionalAttendeesWithNoGaps() {
+    // Only have optional attendees, no mandatory ones, and there are no gaps in their schedule.
+    //
+    // Events  : |--A*-|       |---A*---|
+    //         :       |----B*---|      |---B*--|     (*optional)
+    // Day     : |------------------------------|
+    // Options : 
+
+    Collection<Event> events =
+        Arrays.asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0900AM, false),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartEnd(TIME_0900AM, TIME_1100AM, false),
+                Arrays.asList(PERSON_B)),
+            new Event(
+                "Event 3",
+                TimeRange.fromStartEnd(TIME_0100PM, TIME_0300PM, false),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 4",
+                TimeRange.fromStartEnd(TIME_0300PM, TimeRange.END_OF_DAY, true),
+                Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected = Arrays.asList();

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -364,7 +364,7 @@ public final class FindMeetingQueryTest {
     // Events  :       |--A--|     |--B--|
     //         :             |--C*-|             (*optional)
     // Day     : |-----------------------------|
-    // Options : |--1--|                 |--3--|
+    // Options : |-----|                 |-----|
 
     Collection<Event> events =
         Arrays.asList(
@@ -378,7 +378,7 @@ public final class FindMeetingQueryTest {
                 Arrays.asList(PERSON_B)),
             new Event(
                 "Event 3",
-                TimeRange.fromStartDuration(TIME_0830AM, TIME_0900AM),
+                TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES),
                 Arrays.asList(PERSON_C)));
 
     MeetingRequest request =
@@ -489,7 +489,7 @@ public final class FindMeetingQueryTest {
                 Arrays.asList(PERSON_A)),
             new Event(
                 "Event 2",
-                TimeRange.fromStartEnd(TIME_0900AM, TIME_1100AM, false),
+                TimeRange.fromStartEnd(TIME_0900AM, TIME_0100PM, false),
                 Arrays.asList(PERSON_B)),
             new Event(
                 "Event 3",

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -385,7 +385,6 @@ public final class FindMeetingQueryTest {
         new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
     request.addOptionalAttendee(PERSON_C);
 
-
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
         Arrays.asList(
@@ -479,7 +478,7 @@ public final class FindMeetingQueryTest {
     // Events  : |--A*-|       |---A*---|
     //         :       |----B*---|      |---B*--|     (*optional)
     // Day     : |------------------------------|
-    // Options : 
+    // Options :
 
     Collection<Event> events =
         Arrays.asList(


### PR DESCRIPTION
Scenario:
```
You are going to be adding support for optional attendees for a meeting.
The basic functionality of optional attendees is that if one or more time slots exists so that both 
mandatory and optional attendees can attend, return those time slots. Otherwise, return the time
slots that fit just the mandatory attendees.
```

This PR adds 5 new tests for the optional attendees features, ensures that they are failing appropriately, and then implements the optional attendees feature such that all 26 tests pass now.